### PR TITLE
Remove commit for upgrade test, since the install failed for this old commit (old logrotate/fail2ban bug)

### DIFF
--- a/check_process
+++ b/check_process
@@ -16,7 +16,6 @@
 		setup_private=1
 		setup_public=1
 		upgrade=1
-		upgrade=1	from_commit=9109a4ca898156a354ea5a2b2f0df3ead1945d89
 		backup_restore=1
 		multi_instance=1
 		incorrect_path=1


### PR DESCRIPTION
Which is currently why the app is stuck at level 2 : https://ci-apps.yunohost.org/ci/job/6411

Despite the upgrade working correctly supposedly..