### PR TITLE
App using rm -rf that was unspotted so far ... to be reported as error by the linter

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -104,7 +104,7 @@ ynh_print_info "Upgrading source files..."
 ynh_setup_source "$final_path"
 cp -a "$tmpdir/data" "${final_path}/"
 cp -a "$tmpdir/tpl" "${final_path}/"
-rm -Rf "$tmpdir"
+ynh_secure_remove "$tmpdir"
 
 #=================================================
 # NGINX CONFIGURATION
@@ -147,7 +147,7 @@ ynh_script_progression --message="Upgrading logrotate configuration..."
 # Temporary fix for .txt log file and ynh_use_logrotate
 if [ -d "$final_path/data/log.txt" ]
 then
-    rm -r "$final_path/data/log.txt"
+    ynh_secure_remove "$final_path/data/log.txt"
     touch "$final_path/data/log.txt"
 fi
 ynh_use_logrotate --non-append


### PR DESCRIPTION
c.f. https://github.com/YunoHost/package_linter/commit/4b513b4cd67275dfc597d30ddbfe1801293ad15a#diff-661c3b5fe67e77caea903b5fdb903b5fb6e8277c912d4a4af94e179ade2910baR1019

This app is using some `rm -rf` or similar command that was unspotted so far ... The app is gonna be capped to level 4 by the CI until this is fixed :/ 