### PR TITLE
Don't override (new) official templates with old ones

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "en": "The personal, minimalist, super-fast, no-database delicious clone",
     "fr": "Clone de delicious, rapide, simple et sans base de données."
   },
-  "version": "0.12.1~ynh1",
+  "version": "0.12.1~ynh2",
   "url": "https://github.com/shaarli/Shaarli",
   "license": "MIT",
   "maintainer": {

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -83,7 +83,7 @@ then
 	ynh_setup_source --dest_dir="$final_path"
 
 	cp -a "$tmpdir/data" "$final_path/"
-	cp -a "$tmpdir/tpl" "$final_path/"
+	cp -a -n "$tmpdir/tpl" "$final_path/" # copy without erasing existing templates (from official source)
 
 	# Remove the tmp directory securely
 	ynh_secure_remove --file="$tmpdir"


### PR DESCRIPTION
Fix #65 #67

## Problem
- Templates download from official source are overridden with old version of them during upgrade 

## Solution
- don't copy old template if an official template file already exist

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.
