### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -48,7 +48,7 @@ ynh_add_fail2ban_config --logpath="$install_dir/data/log.txt" --failregex="\s-\s
 ynh_script_progression --message="Adding a configuration file..." --weight=1
 
 # Get the timezone
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 
 # Generate the salt
 salt=$(ynh_string_random 40)


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.